### PR TITLE
Add VLM-YOLO project card to portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,12 @@
     <div class="projects-container">
       <div class="projects">
         <div class="project">
+          <img src="https://raw.githubusercontent.com/tarunk42/AI-Computer-use-using-VLM-and-YOLO/main/resources/output/frame_005.png" alt="AI Computer Use" class="project-img">
+          <h3>AI Computer Use with VLM and YOLO</h3>
+          <p>Pipeline combining YOLOv8 to detect UI elements and a vision-language model to understand tasks, aiming to automate general computer use through screen comprehension.</p>
+          <a href="https://github.com/tarunk42/AI-Computer-use-using-VLM-and-YOLO">View on GitHub</a>
+        </div>
+        <div class="project">
           <img src="html/images/gan.png" alt="GAN Project" class="project-img">
           <h3>Generative Modeling for Conditioned Biomaterial Topography: A GAN-based Approach</h3>
           <p>Developed and evaluated Conditional GAN (cGAN), Deep Convolutional GAN (DCGAN), and Variational AutoEncoder (VAE) on 2000 2D topography images, enhancing biocompatibility and reducing research costs; DCGAN achieved the best FID score of 47.67.</p>


### PR DESCRIPTION
## Summary
- add featured project card for AI Computer Use with VLM and YOLO
- reference remote thumbnail from repository instead of local binary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4cd2ff488331a13d8166ee3c24c2